### PR TITLE
chore: qnexus cross island tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,7 +21,7 @@ jobs:
   test-integration:
     name: Integration
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +77,7 @@ jobs:
                         --html=integration-results.html \
                         --junit-xml=integration-results.xml \
                         --timeout=600 \
+                        --timeout-method=thread \
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
@@ -95,7 +96,7 @@ jobs:
   test-cross-region-integration:
     name: Cross-region Integration
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -149,10 +150,11 @@ jobs:
                         --html=cross-region-integration-results.html \
                         --junit-xml=cross-region-integration-results.xml \
                         --timeout=600 \
+                        --timeout-method=thread \
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
-                        -o addopts="--strict-markers -n 1" \
+                        -o addopts="--strict-markers -n 0" \
                         -vv
 
       - name: Upload cross-region integration test results

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,6 +21,7 @@ jobs:
   test-integration:
     name: Integration
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -75,10 +76,11 @@ jobs:
                         --ignore=integration/cross_region \
                         --html=integration-results.html \
                         --junit-xml=integration-results.xml \
-                        --timeout=100 \
+                        --timeout=600 \
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
+                        -o addopts="--strict-markers -n 2 --reruns 3" \
                         -vv
 
       - name: Upload integration test results
@@ -93,6 +95,7 @@ jobs:
   test-cross-region-integration:
     name: Cross-region Integration
     runs-on: ubuntu-24.04
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -145,10 +148,11 @@ jobs:
           uv run pytest integration/cross_region \
                         --html=cross-region-integration-results.html \
                         --junit-xml=cross-region-integration-results.xml \
-                        --timeout=100 \
+                        --timeout=600 \
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
+                        -o addopts="--strict-markers -n 2 --reruns 3" \
                         -vv
 
       - name: Upload cross-region integration test results

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -77,7 +77,6 @@ jobs:
                         --html=integration-results.html \
                         --junit-xml=integration-results.xml \
                         --timeout=600 \
-                        --timeout-method=thread \
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
@@ -150,11 +149,10 @@ jobs:
                         --html=cross-region-integration-results.html \
                         --junit-xml=cross-region-integration-results.xml \
                         --timeout=600 \
-                        --timeout-method=thread \
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
-                        -o addopts="--strict-markers -n 0" \
+                        -o addopts="--strict-markers -n 1" \
                         -vv
 
       - name: Upload cross-region integration test results

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,7 +80,7 @@ jobs:
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
-                        -o addopts="--strict-markers -n 2 --reruns 3" \
+                        -o addopts="--strict-markers -n 3 --reruns 3" \
                         -vv
 
       - name: Upload integration test results

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -152,7 +152,7 @@ jobs:
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
-                        -o addopts="--strict-markers -n 1" \
+                        -o addopts="--strict-markers -n 2" \
                         -vv
 
       - name: Upload cross-region integration test results

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -75,7 +75,7 @@ jobs:
                         --ignore=integration/cross_region \
                         --html=integration-results.html \
                         --junit-xml=integration-results.xml \
-                        --timeout=600 \
+                        --timeout=100 \
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
@@ -145,7 +145,7 @@ jobs:
           uv run pytest integration/cross_region \
                         --html=cross-region-integration-results.html \
                         --junit-xml=cross-region-integration-results.xml \
-                        --timeout=600 \
+                        --timeout=100 \
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -139,8 +139,6 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
           cache-dependency-glob: uv.lock
-          # Distinct suffix to avoid cache collisions with the normal integration job running in parallel.
-          cache-suffix: cross-region
 
       - name: Run cross-region integration tests
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -98,8 +98,8 @@ jobs:
       matrix:
         python-version: ["3.12"]
     env:
-      NEXUS_QA_HOME_USER_EMAIL: ${{ secrets.NEXUS_CROSS_REGION_QA_USER_EMAIL }}
-      NEXUS_QA_HOME_USER_PASSWORD: ${{ secrets.NEXUS_CROSS_REGION_QA_USER_PASSWORD }}
+      NEXUS_QA_HOME_USER_EMAIL: ${{ secrets.NEXUS_QA_HOME_USER_EMAIL }}
+      NEXUS_QA_HOME_USER_PASSWORD: ${{ secrets.NEXUS_QA_HOME_USER_PASSWORD }}
       NEXUS_DOMAIN: "qa.myqos.com"
       NEXUS_SG_DOMAIN: "sg.qa.myqos.com"
       NEXUS_STORE_TOKENS: "false"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Run integration tests
         run: |
           uv run pytest integration/ \
+                        --ignore=integration/cross_region \
                         --html=integration-results.html \
                         --junit-xml=integration-results.xml \
                         --timeout=600 \
@@ -89,8 +90,78 @@ jobs:
             ./assets/*.css
           name: integration-results
 
+  test-cross-region-integration:
+    name: Cross-region Integration
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+    env:
+      NEXUS_QA_HOME_USER_EMAIL: ${{ secrets.NEXUS_CROSS_REGION_QA_USER_EMAIL }}
+      NEXUS_QA_HOME_USER_PASSWORD: ${{ secrets.NEXUS_CROSS_REGION_QA_USER_PASSWORD }}
+      NEXUS_DOMAIN: "qa.myqos.com"
+      NEXUS_SG_DOMAIN: "sg.qa.myqos.com"
+      NEXUS_STORE_TOKENS: "false"
+      NEXUS_CROSS_REGION_TESTS: "true"
+      NEXUS_HOME_REGION: "sg"
+      NEXUS_TARGET_REGION: "us"
+
+    steps:
+      - name: Validate workflow dispatch inputs
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          if [[ -n "${{ github.event.inputs.pr_number }}" && -n "${{ github.event.inputs.release_tag }}" ]]; then
+            echo "Only one of pr_number or release_tag may be set. Leave both empty to run from main."
+            exit 1
+          fi
+
+      - name: Comment action run link on PR
+        if: ${{ github.event.inputs.pr_number && github.event.inputs.pr_number != '' }}
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            Cross-region integration tests are running on this PR at:
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+          pr-number: ${{ github.event.inputs.pr_number }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+          # Prefer a release tag when provided, otherwise use the PR merge ref or main.
+          ref: ${{ github.event.inputs.release_tag || (github.event.inputs.pr_number && format('refs/pull/{0}/merge', github.event.inputs.pr_number)) || 'main' }}
+
+      - name: Set up uv & venv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+          cache-dependency-glob: uv.lock
+
+      - name: Run cross-region integration tests
+        run: |
+          uv run pytest integration/cross_region \
+                        --html=cross-region-integration-results.html \
+                        --junit-xml=cross-region-integration-results.xml \
+                        --timeout=600 \
+                        -ra --reruns=3 \
+                        --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
+                        --purge-projects \
+                        -vv
+
+      - name: Upload cross-region integration test results
+        if: "!cancelled()"
+        uses: actions/upload-artifact@master
+        with:
+          path: |
+            ./cross-region-integration-results.*
+            ./assets/*.css
+          name: cross-region-integration-results
+
   publish-result-in-slack:
-    needs: test-integration
+    needs: [test-integration, test-cross-region-integration]
     if: "!cancelled()"
     runs-on: ubuntu-24.04
     steps:
@@ -104,7 +175,9 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: ${{ !startsWith(github.ref_name, 'dependabot/') }}
         with:
-          files: "**/integration-results.xml"
+          files: |
+            **/integration-results.xml
+            **/cross-region-integration-results.xml
           comment_title: qnexus integration results
 
       - name: "Post scheduled runs summary in Slack: #nexus-tests"
@@ -118,3 +191,4 @@ jobs:
           slackbottoken: ${{ secrets.NEXUS_TESTS_SLACK_BOT_TOKEN }}
           slackchannel: "C08LQ4ST2JV"
           junitxml_filepath: integration-results.xml
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -139,6 +139,8 @@ jobs:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
           cache-dependency-glob: uv.lock
+          # Distinct suffix to avoid cache collisions with the normal integration job running in parallel.
+          cache-suffix: cross-region
 
       - name: Run cross-region integration tests
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -80,7 +80,7 @@ jobs:
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
-                        -o addopts="--strict-markers -n 3 --reruns 3" \
+                        -o addopts="--strict-markers -n 3" \
                         -vv
 
       - name: Upload integration test results
@@ -152,7 +152,7 @@ jobs:
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
-                        -o addopts="--strict-markers -n 2 --reruns 3" \
+                        -o addopts="--strict-markers -n 1" \
                         -vv
 
       - name: Upload cross-region integration test results

--- a/integration/README.md
+++ b/integration/README.md
@@ -43,3 +43,21 @@ runs, the tests that require unique names might fail.
 
 By default projects created during the test run will not be purged (archived and deleted). Specifying the
 flag `--purge-projects` will make it so all the projects are purged immediately after a test finishes.
+
+## Cross-region job submission tests
+
+The `integration/cross_region` suite verifies that a job can be submitted from a "home" region to a
+different "target" region (e.g. logging in against SG and submitting a job with `target_region="us"`),
+and that its results can be retrieved.
+
+This suite is skipped by default and requires the QA test user to have access to both regions. To enable
+it, set:
+
+- `NEXUS_CROSS_REGION_TESTS` (to any value, to enable the suite)
+- `NEXUS_HOME_REGION` (region to log in against, defaults to `"sg"`)
+- `NEXUS_TARGET_REGION` (region to target job submissions at, defaults to `"us"`)
+- `NEXUS_SG_DOMAIN` / `NEXUS_US_DOMAIN` (if the region's QA domain differs from the production default)
+- `NEXUS_QA_HOME_USER_EMAIL` (user with cross region access)
+- `NEXUS_QA_HOME_USER_PASSWORD` (user creds with cross region access)
+
+Device/system names used per-region are configured in `integration/cross_region/region_config.json`.

--- a/integration/constants.py
+++ b/integration/constants.py
@@ -3,5 +3,5 @@
 # Timeout (in seconds) passed to `qnx.jobs.wait_for(..., timeout=JOB_TIMEOUT)` calls.
 # Kept under the CI job's pytest --timeout (currently 600s) so that a
 # stuck job raises a clean asyncio.TimeoutError from wait_for itself,
-# rather than relying on pytest-timeout which ayncio does not respect. 
+# rather than relying on pytest-timeout which ayncio does not respect.
 JOB_TIMEOUT = 500.0

--- a/integration/constants.py
+++ b/integration/constants.py
@@ -1,0 +1,7 @@
+"""Shared constants used across the qnexus integration test suite."""
+
+# Timeout (in seconds) passed to `qnx.jobs.wait_for(..., timeout=JOB_TIMEOUT)` calls.
+# Kept under the CI job's pytest --timeout (currently 600s) so that a
+# stuck job raises a clean asyncio.TimeoutError from wait_for itself,
+# rather than relying on pytest-timeout which ayncio does not respect. 
+JOB_TIMEOUT = 500.0

--- a/integration/cross_region/conftest.py
+++ b/integration/cross_region/conftest.py
@@ -49,7 +49,7 @@ def target_region() -> Region:
 
 @pytest.fixture(scope="module", autouse=True)
 def authenticated_nexus(home_region: Region) -> Generator[None, None, None]:
-    """Override `authenticated_nexus` to log in against `home_region`, instead of 
+    """Override `authenticated_nexus` to log in against `home_region`, instead of
     the default region used by the rest of the integration suite."""
     try:
         login_no_interaction(

--- a/integration/cross_region/conftest.py
+++ b/integration/cross_region/conftest.py
@@ -36,13 +36,13 @@ def pytest_collection_modifyitems(
 
 
 @pytest.fixture(scope="module")
-def home_region() -> Region:
+def home_region() -> str:
     """The region the test user logs in against."""
     return os.getenv("NEXUS_HOME_REGION", "sg")
 
 
 @pytest.fixture(scope="module")
-def target_region() -> Region:
+def target_region() -> str:
     """The region that jobs are submitted to from the home region."""
     return os.getenv("NEXUS_TARGET_REGION", "us")
 

--- a/integration/cross_region/conftest.py
+++ b/integration/cross_region/conftest.py
@@ -1,0 +1,60 @@
+"""Fixtures shared across the cross-region job submission tests.
+
+Required env vars to run this suite
+
+``NEXUS_CROSS_REGION_TESTS``  set (to any value) to enable this suite.
+``NEXUS_HOME_REGION``         region to log in against (default: "sg").
+``NEXUS_TARGET_REGION``       region job submissions are targeted at (default: "us").
+``NEXUS_QA_HOME_USER_EMAIL``  user with cross region access
+``NEXUS_QA_HOME_USER_PASSWORD``  user creds with cross region access
+"""
+
+import os
+from typing import Generator
+
+import pytest
+
+import qnexus as qnx
+from qnexus.client.auth import login_no_interaction
+from qnexus.config import CONFIG
+from qnexus.models.region import Region
+
+
+def pytest_collection_modifyitems(
+    items: list[pytest.Item], config: pytest.Config
+) -> None:
+    """Skip all cross_region tests when NEXUS_CROSS_REGION_TESTS env var is not set."""
+    if os.getenv("NEXUS_CROSS_REGION_TESTS") is not None:
+        return
+
+    skip = pytest.mark.skip(
+        reason="Cross-region tests skipped: NEXUS_CROSS_REGION_TESTS env var not set."
+    )
+    for item in items:
+        if "cross_region" in str(item.path):
+            item.add_marker(skip)
+
+
+@pytest.fixture(scope="module")
+def home_region() -> Region:
+    """The region the test user logs in against."""
+    return os.getenv("NEXUS_HOME_REGION", "sg")
+
+
+@pytest.fixture(scope="module")
+def target_region() -> Region:
+    """The region that jobs are submitted to from the home region."""
+    return os.getenv("NEXUS_TARGET_REGION", "us")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def authenticated_nexus(home_region: Region) -> Generator[None, None, None]:
+    """Override `authenticated_nexus` to log in against `home_region`, instead of 
+    the default region used by the rest of the integration suite."""
+    try:
+        login_no_interaction(
+            CONFIG.qa_home_user_email, CONFIG.qa_home_user_password, region=home_region
+        )
+        yield
+    finally:
+        qnx.auth.logout()

--- a/integration/cross_region/region_config.json
+++ b/integration/cross_region/region_config.json
@@ -1,0 +1,12 @@
+{
+  "us": {
+    "helios_sc_device": "Helios-1SC",
+    "helios_ng_device": "Helios-1E",
+    "og_device": "H2-1E"
+  },
+  "sg": {
+    "helios_sc_device": "Helios-2SC",
+    "helios_ng_device": "Helios-2E",
+    "og_device": ""
+  }
+}

--- a/integration/cross_region/region_devices.py
+++ b/integration/cross_region/region_devices.py
@@ -1,5 +1,4 @@
-"""Helper to load per-region device names for cross-region integration tests.
-"""
+"""Helper to load per-region device names for cross-region integration tests."""
 
 import json
 from pathlib import Path

--- a/integration/cross_region/region_devices.py
+++ b/integration/cross_region/region_devices.py
@@ -1,0 +1,42 @@
+"""Helper to load per-region device names for cross-region integration tests.
+"""
+
+import json
+from pathlib import Path
+from typing import cast
+
+_CROSS_REGION_DIR = Path(__file__).parent
+_REGION_CONFIG_PATH = _CROSS_REGION_DIR / "region_config.json"
+
+
+def _load_config() -> dict[str, dict[str, str]]:
+    with open(_REGION_CONFIG_PATH) as f:
+        return cast(dict[str, dict[str, str]], json.load(f))
+
+
+_ALL_REGION_CONFIGS: dict[str, dict[str, str]] = _load_config()
+
+
+class _DeviceValidationDict(dict[str, str]):
+    """A dict of devices for a region that raises a helpful error if a
+    requested device hasn't been configured for that region."""
+
+    def __getitem__(self, key: str) -> str:
+        value = dict.__getitem__(self, key)
+        if not value or not value.strip():
+            raise ValueError(
+                f"Device '{key}' is not configured for this region. "
+                "Please update integration/cross_region/region_config.json."
+            )
+        return value
+
+
+def load_region_devices(region: str) -> dict[str, str]:
+    """Return the device/system names configured for the given region."""
+
+    if region not in _ALL_REGION_CONFIGS:
+        raise ValueError(
+            f"Unknown region '{region}'. Valid regions: {list(_ALL_REGION_CONFIGS)}"
+        )
+
+    return _DeviceValidationDict(_ALL_REGION_CONFIGS[region])

--- a/integration/cross_region/test_cross_region_job_submission.py
+++ b/integration/cross_region/test_cross_region_job_submission.py
@@ -1,0 +1,262 @@
+"""Cross-region job submission tests.
+
+These tests submit jobs from a "home" region (logged in against, e.g. SG)
+targeting a different "target" region (e.g. US) via the ``target_region``
+kwarg on job submission, and verify that the job completes and its results
+can be retrieved.
+"""
+
+from typing import Callable, ContextManager, cast
+
+import pytest
+from hugr.package import Package
+from pathlib import Path
+from hugr.qsystem.result import QsysResult
+from pytket.backends.backendinfo import BackendInfo
+from pytket.backends.backendresult import BackendResult
+from quantinuum_schemas.models.backend_config import (
+    AerConfig,
+    HeliosConfig,
+    HeliosEmulatorConfig,
+)
+from pytket.circuit import Circuit, Bit
+import qnexus.exceptions as qnx_exc
+
+import qnexus as qnx
+from test_qir.py import make_qir_bitcode_from_file
+from qnexus.exceptions import ResourceCreateFailed
+from qnexus.models.references import ExecutionResultRef, ProjectRef, CircuitRef, QIRRef, QIRResult, ResultVersions
+from qnexus.models.region import Region
+from cross_region.region_devices import load_region_devices
+import pyqir
+
+
+def test_cross_region_execute_job_hugr_ng(
+    test_case_name: str,
+    create_project: Callable[[str], ContextManager[ProjectRef]],
+    qa_hugr_package: Package,
+    target_region: Region,
+) -> None:
+    """Test the execution of a cross island Hugr program on an NG device"""
+
+    device_name = load_region_devices(target_region)["helios_ng_device"]
+
+    with create_project(f"project for {test_case_name}") as project_ref:
+        n_shots = 10
+
+        hugr_ref = qnx.hugr.upload(
+            hugr_package=qa_hugr_package,
+            name=f"hugr for {test_case_name}",
+            project=project_ref,
+        )
+
+        job_ref = qnx.start_execute_job(
+            programs=[hugr_ref],
+            n_shots=[n_shots],
+            backend_config=HeliosConfig(
+                system_name=device_name,
+                emulator_config=HeliosEmulatorConfig(),
+            ),
+            project=project_ref,
+            name=f"cross-region job for {test_case_name}",
+            n_qubits=[5],
+            max_cost=[10.0],
+            target_region=target_region,
+        )
+
+        qnx.jobs.wait_for(job_ref)
+
+        results = qnx.jobs.results(job_ref)
+        assert len(results) == 1
+        result_ref = results[0]
+        assert isinstance(result_ref, ExecutionResultRef)
+
+        qsys_result = cast(QsysResult, result_ref.download_result())
+        assert len(qsys_result.results) == n_shots
+
+
+def test_cross_region_execute_job_qir_ng(
+        test_case_name: str,
+        create_qir_in_project: Callable[[str, str, bytes], ContextManager[QIRRef]],
+        target_region: Region,
+    ) -> None:
+     """Test the execution of a cross island QIR program on an NG device"""
+
+     ng_device_name = load_region_devices(target_region)["helios_ng_device"]
+
+     project_name = f"project for {test_case_name}"
+     qir_name = f"qir for {test_case_name}"
+     
+     with create_qir_in_project(
+             project_name,
+             qir_name,
+             make_qir_bitcode_from_file("base.ll"),
+         ) as qir_ref:
+             project_ref = qnx.projects.get(name=project_name)
+     
+             job_ref = qnx.start_execute_job(
+                 programs=[qir_ref],
+                 n_shots=[10],
+                 max_cost=[10.0],
+                 backend_config=qnx.QuantinuumConfig(
+                     device_name=ng_device_name, compiler_options={"max-qubits": 5}
+                 ),
+                 project=project_ref,
+                 name=f"qir job for {test_case_name}",
+                 target_region=target_region,
+             )
+     
+             qnx.jobs.wait_for(job_ref)
+     
+             result_ref = qnx.jobs.results(job_ref)[0]
+             assert isinstance(result_ref, ExecutionResultRef)
+             results = result_ref.download_result()
+             # Assert this is a QIR compliant result
+             assert isinstance(results, QIRResult)
+             escaped_results = results.results.encode("unicode_escape").decode()
+             assert "HEADER\\tschema_id\\tlabeled" in escaped_results
+             # Can't assert the value is the same, so just check the output is there
+             assert "OUTPUT\\tTUPLE\\t2\\tt0" in escaped_results
+     
+             v4_results = result_ref.download_result(version=ResultVersions.RAW)
+             # Assert this is in v4 format
+             assert isinstance(v4_results, QsysResult)
+             assert v4_results.results[0].entries[0][0] == "USER:QIRTUPLE:t0"
+
+
+def test_cross_region_execute_job_qir_og(
+    test_case_name: str,
+    create_qir_in_project: Callable[[str, str, bytes], ContextManager[QIRRef]],
+    qa_qir_bitcode: bytes,
+    target_region: Region,
+) -> None:
+    """Test the execution of a cross island QIR program on an OG device"""
+
+    project_name = f"project for {test_case_name}"
+    qir_name = f"qir for {test_case_name}"
+
+    with create_qir_in_project(
+        project_name,
+        qir_name,
+        qa_qir_bitcode,
+    ) as qir_program_ref:
+        device_name = load_region_devices(target_region)["og_device"]
+
+        project_ref = qnx.projects.get_or_create(name=project_name)
+
+        qir_program_ref = qnx.qir.get(name=qir_name)
+
+        job_ref = qnx.start_execute_job(
+            programs=[qir_program_ref],
+            n_shots=[10],
+            backend_config=qnx.QuantinuumConfig(device_name=device_name),
+            project=project_ref,
+            name=f"qir job for {test_case_name}",
+            target_region=target_region,
+        )
+
+        qnx.jobs.wait_for(job_ref)
+
+        results = qnx.jobs.results(job_ref)
+
+        assert len(results) == 1
+        result_ref = results[0]
+
+        assert isinstance(result_ref, ExecutionResultRef)
+        assert isinstance(result_ref.download_backend_info(), BackendInfo)
+        assert isinstance(result_ref.get_input(), QIRRef)
+
+        assert result_ref.get_input().id == qir_program_ref.id
+
+        qir_result_ref = qnx.jobs.results(job_ref)[0]
+
+        assert isinstance(qir_result_ref, ExecutionResultRef)
+        qir_result = qir_result_ref.download_result()
+        assert isinstance(qir_result, BackendResult)
+        assert sum(qir_result.get_counts().values()) == 10
+        assert qir_result.get_bitlist() == [Bit("c", 2), Bit("c", 1), Bit("c", 0)]
+
+
+def test_cross_region_execute_job_pytket_og(
+    test_case_name: str,
+    create_circuit_in_project: Callable[
+        [Circuit, str, str], ContextManager[CircuitRef]
+    ],
+    test_circuit: Circuit,
+    target_region: Region,
+) -> None:
+    """Test the execution of a cross-region pytket circuit on an OG device."""
+
+    project_name = f"project for {test_case_name}"
+    circuit_name = f"circuit for {test_case_name}"
+
+    with create_circuit_in_project(
+        test_circuit,
+        project_name,
+        circuit_name,
+    ) as circuit_ref:
+        device_name = load_region_devices(target_region)["og_device"]
+
+        project_ref = qnx.projects.get_or_create(name=project_name)
+
+        job_ref = qnx.start_execute_job(
+            programs=[circuit_ref],
+            n_shots=[10],
+            backend_config=qnx.QuantinuumConfig(device_name=device_name),
+            project=project_ref,
+            name=f"pytket job for {test_case_name}",
+            target_region=target_region,
+        )
+
+        qnx.jobs.wait_for(job_ref)
+
+        results = qnx.jobs.results(job_ref)
+        assert len(results) == 1
+        result_ref = results[0]
+
+        assert isinstance(result_ref, ExecutionResultRef)
+        assert isinstance(result_ref.download_backend_info(), BackendInfo)
+        assert isinstance(result_ref.get_input(), CircuitRef)
+        assert result_ref.get_input().id == circuit_ref.id
+
+        pytket_result = result_ref.download_result()
+        assert isinstance(pytket_result, BackendResult)
+        assert sum(pytket_result.get_counts().values()) == 10
+
+
+def test_reject_cross_region_job_for_nexus_simulators(
+    test_case_name: str,
+    create_project: Callable[[str], ContextManager[ProjectRef]],
+    create_circuit_in_project: Callable[
+            [Circuit, str, str], ContextManager[CircuitRef]
+        ],
+    qa_hugr_package: Package,
+    target_region: Region,
+    test_circuit: Circuit,
+) -> None:
+    """Nexus-hosted simulators (e.g. Aer) cannot be targeted at a region
+    other than the one the job is submitted from."""
+
+    local_project_name = f"project for {test_case_name}"
+    local_circuit_name = f"circuit for {test_case_name}"
+    
+    with create_circuit_in_project(
+            test_circuit,
+            local_project_name,
+            local_circuit_name,
+        ) as circ_ref:
+            my_proj = qnx.projects.get_or_create(local_project_name)
+    
+            with pytest.raises(qnx_exc.ResourceCreateFailed) as exc:
+                qnx.start_execute_job(
+                                programs=[circ_ref],
+                                n_shots=[10],
+                                backend_config=AerConfig(),
+                                project=my_proj,
+                                name=f"cross-region simulator job for {test_case_name}",
+                                target_region=target_region,
+                            )
+                assert exc.value.status_code == 400
+                assert "Nexus hosted simulators can only be run in the current region" in (
+                    exc.value.message
+                )

--- a/integration/cross_region/test_cross_region_job_submission.py
+++ b/integration/cross_region/test_cross_region_job_submission.py
@@ -23,7 +23,14 @@ import qnexus.exceptions as qnx_exc
 
 import qnexus as qnx
 from test_qir.py import make_qir_bitcode_from_file
-from qnexus.models.references import ExecutionResultRef, ProjectRef, CircuitRef, QIRRef, QIRResult, ResultVersions
+from qnexus.models.references import (
+    ExecutionResultRef,
+    ProjectRef,
+    CircuitRef,
+    QIRRef,
+    QIRResult,
+    ResultVersions,
+)
 from qnexus.models.region import Region
 from cross_region.region_devices import load_region_devices
 
@@ -73,52 +80,52 @@ def test_cross_region_execute_job_hugr_ng(
 
 
 def test_cross_region_execute_job_qir_ng(
-        test_case_name: str,
-        create_qir_in_project: Callable[[str, str, bytes], ContextManager[QIRRef]],
-        target_region: Region,
-    ) -> None:
-     """Test the execution of a cross island QIR program on an NG device"""
+    test_case_name: str,
+    create_qir_in_project: Callable[[str, str, bytes], ContextManager[QIRRef]],
+    target_region: Region,
+) -> None:
+    """Test the execution of a cross island QIR program on an NG device"""
 
-     ng_device_name = load_region_devices(target_region)["helios_ng_device"]
+    ng_device_name = load_region_devices(target_region)["helios_ng_device"]
 
-     project_name = f"project for {test_case_name}"
-     qir_name = f"qir for {test_case_name}"
-     
-     with create_qir_in_project(
-             project_name,
-             qir_name,
-             make_qir_bitcode_from_file("base.ll"),
-         ) as qir_ref:
-             project_ref = qnx.projects.get(name=project_name)
-     
-             job_ref = qnx.start_execute_job(
-                 programs=[qir_ref],
-                 n_shots=[10],
-                 max_cost=[10.0],
-                 backend_config=qnx.QuantinuumConfig(
-                     device_name=ng_device_name, compiler_options={"max-qubits": 5}
-                 ),
-                 project=project_ref,
-                 name=f"qir job for {test_case_name}",
-                 target_region=target_region,
-             )
-     
-             qnx.jobs.wait_for(job_ref)
-     
-             result_ref = qnx.jobs.results(job_ref)[0]
-             assert isinstance(result_ref, ExecutionResultRef)
-             results = result_ref.download_result()
-             # Assert this is a QIR compliant result
-             assert isinstance(results, QIRResult)
-             escaped_results = results.results.encode("unicode_escape").decode()
-             assert "HEADER\\tschema_id\\tlabeled" in escaped_results
-             # Can't assert the value is the same, so just check the output is there
-             assert "OUTPUT\\tTUPLE\\t2\\tt0" in escaped_results
-     
-             v4_results = result_ref.download_result(version=ResultVersions.RAW)
-             # Assert this is in v4 format
-             assert isinstance(v4_results, QsysResult)
-             assert v4_results.results[0].entries[0][0] == "USER:QIRTUPLE:t0"
+    project_name = f"project for {test_case_name}"
+    qir_name = f"qir for {test_case_name}"
+
+    with create_qir_in_project(
+        project_name,
+        qir_name,
+        make_qir_bitcode_from_file("base.ll"),
+    ) as qir_ref:
+        project_ref = qnx.projects.get(name=project_name)
+
+        job_ref = qnx.start_execute_job(
+            programs=[qir_ref],
+            n_shots=[10],
+            max_cost=[10.0],
+            backend_config=qnx.QuantinuumConfig(
+                device_name=ng_device_name, compiler_options={"max-qubits": 5}
+            ),
+            project=project_ref,
+            name=f"qir job for {test_case_name}",
+            target_region=target_region,
+        )
+
+        qnx.jobs.wait_for(job_ref)
+
+        result_ref = qnx.jobs.results(job_ref)[0]
+        assert isinstance(result_ref, ExecutionResultRef)
+        results = result_ref.download_result()
+        # Assert this is a QIR compliant result
+        assert isinstance(results, QIRResult)
+        escaped_results = results.results.encode("unicode_escape").decode()
+        assert "HEADER\\tschema_id\\tlabeled" in escaped_results
+        # Can't assert the value is the same, so just check the output is there
+        assert "OUTPUT\\tTUPLE\\t2\\tt0" in escaped_results
+
+        v4_results = result_ref.download_result(version=ResultVersions.RAW)
+        # Assert this is in v4 format
+        assert isinstance(v4_results, QsysResult)
+        assert v4_results.results[0].entries[0][0] == "USER:QIRTUPLE:t0"
 
 
 def test_cross_region_execute_job_qir_og(
@@ -225,8 +232,8 @@ def test_reject_cross_region_job_for_nexus_simulators(
     test_case_name: str,
     create_project: Callable[[str], ContextManager[ProjectRef]],
     create_circuit_in_project: Callable[
-            [Circuit, str, str], ContextManager[CircuitRef]
-        ],
+        [Circuit, str, str], ContextManager[CircuitRef]
+    ],
     qa_hugr_package: Package,
     target_region: Region,
     test_circuit: Circuit,
@@ -236,24 +243,24 @@ def test_reject_cross_region_job_for_nexus_simulators(
 
     local_project_name = f"project for {test_case_name}"
     local_circuit_name = f"circuit for {test_case_name}"
-    
+
     with create_circuit_in_project(
-            test_circuit,
-            local_project_name,
-            local_circuit_name,
-        ) as circ_ref:
-            my_proj = qnx.projects.get_or_create(local_project_name)
-    
-            with pytest.raises(qnx_exc.ResourceCreateFailed) as exc:
-                qnx.start_execute_job(
-                                programs=[circ_ref],
-                                n_shots=[10],
-                                backend_config=AerConfig(),
-                                project=my_proj,
-                                name=f"cross-region simulator job for {test_case_name}",
-                                target_region=target_region,
-                            )
-                assert exc.value.status_code == 400
-                assert "Nexus hosted simulators can only be run in the current region" in (
-                    exc.value.message
-                )
+        test_circuit,
+        local_project_name,
+        local_circuit_name,
+    ) as circ_ref:
+        my_proj = qnx.projects.get_or_create(local_project_name)
+
+        with pytest.raises(qnx_exc.ResourceCreateFailed) as exc:
+            qnx.start_execute_job(
+                programs=[circ_ref],
+                n_shots=[10],
+                backend_config=AerConfig(),
+                project=my_proj,
+                name=f"cross-region simulator job for {test_case_name}",
+                target_region=target_region,
+            )
+            assert exc.value.status_code == 400
+            assert "Nexus hosted simulators can only be run in the current region" in (
+                exc.value.message
+            )

--- a/integration/cross_region/test_cross_region_job_submission.py
+++ b/integration/cross_region/test_cross_region_job_submission.py
@@ -10,7 +10,6 @@ from typing import Callable, ContextManager, cast
 
 import pytest
 from hugr.package import Package
-from pathlib import Path
 from hugr.qsystem.result import QsysResult
 from pytket.backends.backendinfo import BackendInfo
 from pytket.backends.backendresult import BackendResult
@@ -24,11 +23,9 @@ import qnexus.exceptions as qnx_exc
 
 import qnexus as qnx
 from test_qir.py import make_qir_bitcode_from_file
-from qnexus.exceptions import ResourceCreateFailed
 from qnexus.models.references import ExecutionResultRef, ProjectRef, CircuitRef, QIRRef, QIRResult, ResultVersions
 from qnexus.models.region import Region
 from cross_region.region_devices import load_region_devices
-import pyqir
 
 
 def test_cross_region_execute_job_hugr_ng(

--- a/integration/cross_region/test_cross_region_job_submission.py
+++ b/integration/cross_region/test_cross_region_job_submission.py
@@ -32,6 +32,8 @@ from qnexus.models.references import (
     ResultVersions,
 )
 from qnexus.models.region import Region
+
+from constants import JOB_TIMEOUT
 from cross_region.region_devices import load_region_devices
 
 
@@ -68,7 +70,7 @@ def test_cross_region_execute_job_hugr_ng(
             target_region=target_region,
         )
 
-        qnx.jobs.wait_for(job_ref)
+        qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
 
         results = qnx.jobs.results(job_ref)
         assert len(results) == 1
@@ -110,7 +112,7 @@ def test_cross_region_execute_job_qir_ng(
             target_region=target_region,
         )
 
-        qnx.jobs.wait_for(job_ref)
+        qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
 
         result_ref = qnx.jobs.results(job_ref)[0]
         assert isinstance(result_ref, ExecutionResultRef)
@@ -159,7 +161,7 @@ def test_cross_region_execute_job_qir_og(
             target_region=target_region,
         )
 
-        qnx.jobs.wait_for(job_ref)
+        qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
 
         results = qnx.jobs.results(job_ref)
 
@@ -212,7 +214,7 @@ def test_cross_region_execute_job_pytket_og(
             target_region=target_region,
         )
 
-        qnx.jobs.wait_for(job_ref)
+        qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
 
         results = qnx.jobs.results(job_ref)
         assert len(results) == 1

--- a/integration/cross_region/test_cross_region_job_submission.py
+++ b/integration/cross_region/test_cross_region_job_submission.py
@@ -22,7 +22,7 @@ from pytket.circuit import Circuit, Bit
 import qnexus.exceptions as qnx_exc
 
 import qnexus as qnx
-from test_qir.py import make_qir_bitcode_from_file
+from test_qir import make_qir_bitcode_from_file
 from qnexus.models.references import (
     ExecutionResultRef,
     ProjectRef,

--- a/integration/test_backend_configs.py
+++ b/integration/test_backend_configs.py
@@ -12,6 +12,8 @@ from qnexus.models.references import (
     ProjectRef,
 )
 
+from constants import JOB_TIMEOUT
+
 CONFIGS_REQUIRE_NO_MEASURE = [qnx.AerUnitaryConfig]
 
 
@@ -43,7 +45,7 @@ def test_basic_backend_config_usage(
             project=project_ref,
         )
 
-        qnx.jobs.wait_for(compile_job_ref)
+        qnx.jobs.wait_for(compile_job_ref, timeout=JOB_TIMEOUT)
 
         # Check the backend config as stored in Nexus matches the one specified
         # at job submission
@@ -75,7 +77,7 @@ def test_basic_backend_config_usage(
             project=project_ref,
         )
 
-        qnx.jobs.wait_for(execute_job_ref)
+        qnx.jobs.wait_for(execute_job_ref, timeout=JOB_TIMEOUT)
 
         execute_job_result_refs = qnx.jobs.results(execute_job_ref)
 

--- a/integration/test_circuits.py
+++ b/integration/test_circuits.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 from pytket.circuit import Circuit
 
+from constants import JOB_TIMEOUT
 import qnexus as qnx
 import qnexus.exceptions as qnx_exc
 from qnexus.models.annotations import PropertiesDict
@@ -157,6 +158,7 @@ def test_circuit_get_cost(
                 backend_config=qnx.QuantinuumConfig(device_name=device_name),
                 syntax_checker=syntax_checker,
                 project=my_proj,
+                timeout=JOB_TIMEOUT,
             )
 
             assert isinstance(cost, float)

--- a/integration/test_compiler_options.py
+++ b/integration/test_compiler_options.py
@@ -11,6 +11,8 @@ from qnexus.models.references import (
     CompileJobRef,
 )
 
+from constants import JOB_TIMEOUT
+
 
 def assert_op_count_in_circuit(
     circuit: Circuit, op: OpType, should_be_gt_0: bool
@@ -66,7 +68,7 @@ def test_target_2qb_gate(
         backend_config=config,
         skip_intermediate_circuits=True,
     ) as compile_job_ref:
-        qnx.jobs.wait_for(compile_job_ref)
+        qnx.jobs.wait_for(compile_job_ref, timeout=JOB_TIMEOUT)
         compile_result = qnx.jobs.results(compile_job_ref)[0]
         assert isinstance(compile_result, CompilationResultRef)
         compiled_circuit_ref = compile_result.get_output()

--- a/integration/test_gpu_decoder_config.py
+++ b/integration/test_gpu_decoder_config.py
@@ -3,9 +3,10 @@
 from typing import Callable, ContextManager
 
 import pandas as pd
+import pytest
 
 import qnexus as qnx
-from qnexus.models.job_status import JobStatusEnum
+import qnexus.exceptions as qnx_exc
 from qnexus.models.references import GpuDecoderConfigRef, Ref
 
 
@@ -40,6 +41,9 @@ def test_gpu_decoder_config_download(
         test_ref_serialisation("gpu_decoder_config", gpu_decoder_config_ref_by_id)
 
 
+# NOTE: Enable once this is implemented:
+#       https://cqc.atlassian.net/browse/NRP-3571
+@pytest.mark.skip(reason="Enable once NRP-3571 is implemented")
 def test_gpu_decoder_config_flow(
     test_case_name: str,
     create_gpu_decoder_config_in_project: Callable[
@@ -81,19 +85,19 @@ def test_gpu_decoder_config_flow(
             qir=qa_qir_bitcode, name=qir_name, project=proj_ref
         )
 
-        execute_job_ref = qnx.start_execute_job(
-            programs=[qir_program_ref],
-            name=f"qir gpu decoder config execute job for {test_case_name}",
-            n_shots=[100],
-            max_cost=[10.0],
-            backend_config=qnx.QuantinuumConfig(
-                device_name="H2-1E",
-            ),
-            gpu_decoder_config=gpu_decoder_config_ref,
-            project=proj_ref,
-        )
+        with pytest.raises(qnx_exc.ResourceCreateFailed) as rcf:
+            qnx.start_execute_job(
+                programs=[qir_program_ref],
+                name=f"qir gpu decoder config execute job for {test_case_name}",
+                n_shots=[100],
+                max_cost=[10.0],
+                backend_config=qnx.QuantinuumConfig(
+                    device_name="H2-1E",
+                ),
+                gpu_decoder_config=gpu_decoder_config_ref,
+                project=proj_ref,
+            )
 
-        # Don't fully submit the job (July 2025)
-        qnx.jobs.wait_for(execute_job_ref, wait_for_status=JobStatusEnum.QUEUED)
-        qnx.jobs.cancel(execute_job_ref)
-        qnx.jobs.wait_for(execute_job_ref, wait_for_status=JobStatusEnum.CANCELLED)
+        # TODO: update with expected status code and error message
+        assert rcf.value.status_code == 400
+        assert "Unsupported message" in rcf.value.message

--- a/integration/test_gpu_decoder_config.py
+++ b/integration/test_gpu_decoder_config.py
@@ -94,6 +94,6 @@ def test_gpu_decoder_config_flow(
         )
 
         # Don't fully submit the job (July 2025)
-        qnx.jobs.wait_for(execute_job_ref, wait_for_status=JobStatusEnum.SUBMITTED)
+        qnx.jobs.wait_for(execute_job_ref, wait_for_status=JobStatusEnum.QUEUED)
         qnx.jobs.cancel(execute_job_ref)
         qnx.jobs.wait_for(execute_job_ref, wait_for_status=JobStatusEnum.CANCELLED)

--- a/integration/test_jobs.py
+++ b/integration/test_jobs.py
@@ -32,6 +32,8 @@ from qnexus.models.references import (
     Ref,
 )
 
+from constants import JOB_TIMEOUT
+
 # The following global variables and autoused fixture are a
 # bit of a hack to have global identifiers for the resources
 # used by the `*job_get` tests in this suite. Using the same name for the
@@ -208,7 +210,7 @@ def test_submit_compile(
     ) as compile_job_ref:
         assert isinstance(compile_job_ref, CompileJobRef)
 
-        qnx.jobs.wait_for(compile_job_ref)
+        qnx.jobs.wait_for(compile_job_ref, timeout=JOB_TIMEOUT)
 
         compile_results = qnx.jobs.results(compile_job_ref)
 
@@ -312,7 +314,7 @@ def test_get_results_for_incomplete_compile(
         assert compile_item.get_input().id == circ_ref.id
 
         # check the job after completion
-        qnx.jobs.wait_for(compile_job_ref)
+        qnx.jobs.wait_for(compile_job_ref, timeout=JOB_TIMEOUT)
         complete_results = qnx.jobs.results(compile_job_ref, allow_incomplete=True)
         assert len(complete_results) == 1
         assert isinstance(complete_results[0], CompilationResultRef)
@@ -365,7 +367,7 @@ def test_submit_execute(
         circuit=test_circuit,
         circuit_name=circuit_name,
     ) as execute_job_ref:
-        qnx.jobs.wait_for(execute_job_ref)
+        qnx.jobs.wait_for(execute_job_ref, timeout=JOB_TIMEOUT)
 
         execute_results = qnx.jobs.results(execute_job_ref)
 
@@ -459,7 +461,7 @@ def test_get_results_for_incomplete_execute(
         assert isinstance(execute_job_ref, ExecuteJobRef)
 
         with pytest.raises(qnx_exc.JobError):
-            qnx.jobs.wait_for(execute_job_ref)
+            qnx.jobs.wait_for(execute_job_ref, timeout=JOB_TIMEOUT)
 
         with pytest.raises(qnx_exc.ResourceFetchFailed):
             qnx.jobs.results(execute_job_ref)
@@ -523,7 +525,7 @@ def test_wait_for_raises_on_job_error(
             qnx.jobs.results(failing_job_ref)
 
         with pytest.raises(qnx_exc.JobError):
-            qnx.jobs.wait_for(failing_job_ref)
+            qnx.jobs.wait_for(failing_job_ref, timeout=JOB_TIMEOUT)
 
 
 def test_results_not_available_error(
@@ -557,7 +559,7 @@ def test_results_not_available_error(
         with pytest.raises(qnx_exc.ResourceFetchFailed):
             qnx.jobs.results(execute_job_ref)
 
-        qnx.jobs.wait_for(execute_job_ref)
+        qnx.jobs.wait_for(execute_job_ref, timeout=JOB_TIMEOUT)
 
         execute_results = qnx.jobs.results(execute_job_ref)
 
@@ -671,7 +673,7 @@ def test_job_cost(
 
     assert isinstance(execute_job_ref, ExecuteJobRef)
 
-    qnx.jobs.wait_for(execute_job_ref)
+    qnx.jobs.wait_for(execute_job_ref, timeout=JOB_TIMEOUT)
 
     job_ref = qnx.jobs.get(id=execute_job_ref.id)
     assert job_ref.last_status_detail is not None
@@ -709,7 +711,7 @@ def test_job_cost_confidence(
             name="Circuit cost confidence estimation job",
         )
 
-        qnx.jobs.wait_for(execute_job_ref)
+        qnx.jobs.wait_for(execute_job_ref, timeout=JOB_TIMEOUT)
 
         cost_confidence = qnx.jobs.cost_confidence(execute_job_ref)
         assert isinstance(cost_confidence, list)

--- a/integration/test_qir.py
+++ b/integration/test_qir.py
@@ -22,6 +22,8 @@ from qnexus.models.references import (
     ResultVersions,
 )
 
+from constants import JOB_TIMEOUT
+
 
 def test_qir_create_and_update(
     test_case_name: str,
@@ -156,7 +158,7 @@ def test_execution(
             name=f"qir job for {test_case_name}",
         )
 
-        qnx.jobs.wait_for(job_ref)
+        qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
 
         results = qnx.jobs.results(job_ref)
 
@@ -205,7 +207,7 @@ def test_execution_on_NG_devices(
             name=f"qir job for {test_case_name}",
         )
 
-        qnx.jobs.wait_for(job_ref)
+        qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
 
         result_ref = qnx.jobs.results(job_ref)[0]
         assert isinstance(result_ref, ExecutionResultRef)

--- a/integration/test_qir.py
+++ b/integration/test_qir.py
@@ -246,6 +246,7 @@ def test_costing_qir_on_NG_devices(
             programs=[qir_ref],
             n_shots=[10],
             project=project_ref,
+            timeout=JOB_TIMEOUT,
         )
         assert isinstance(cost, float)
 
@@ -271,6 +272,7 @@ def test_qir_cost_confidence(
             programs=[qir_ref],
             n_shots=[10],
             project=project_ref,
+            timeout=JOB_TIMEOUT,
         )
         assert isinstance(cost_confidence, list)
         assert len(cost_confidence) > 0

--- a/integration/test_qsys_jobs.py
+++ b/integration/test_qsys_jobs.py
@@ -21,6 +21,8 @@ from qnexus.models.references import (
     ResultVersions,
 )
 
+from constants import JOB_TIMEOUT
+
 
 @pytest.mark.parametrize(
     "backend_config",
@@ -61,7 +63,7 @@ def test_guppy_execution(
             max_cost=[10.0],
         )
 
-        qnx.jobs.wait_for(job_ref)
+        qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
 
         results = qnx.jobs.results(job_ref)
 

--- a/integration/test_qsys_jobs.py
+++ b/integration/test_qsys_jobs.py
@@ -118,6 +118,7 @@ def test_hugr_costing(
             programs=[hugr_ref],
             n_shots=[10],
             project=project_ref,
+            timeout=JOB_TIMEOUT,
         )
         assert isinstance(cost, float)
 
@@ -141,6 +142,7 @@ def test_hugr_cost_confidence(
             programs=[hugr_ref],
             n_shots=[10],
             project=project_ref,
+            timeout=JOB_TIMEOUT,
         )
         assert isinstance(cost_confidence, list)
         assert len(cost_confidence) > 0

--- a/integration/test_results.py
+++ b/integration/test_results.py
@@ -20,6 +20,8 @@ from qnexus.models.references import (
     ProjectRef,
 )
 
+from constants import JOB_TIMEOUT
+
 
 def test_fetch_qsys_result(
     test_case_name: str,
@@ -51,7 +53,7 @@ def test_fetch_qsys_result(
             max_cost=[10.0],
         )
 
-        qnx.jobs.wait_for(job_ref)
+        qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
 
         results = qnx.jobs.results(job_ref)
 
@@ -106,7 +108,7 @@ def test_fetch_pytket_result(
         circuit=test_circuit,
         circuit_name=circuit_name,
     ) as execute_job_ref:
-        qnx.jobs.wait_for(execute_job_ref)
+        qnx.jobs.wait_for(execute_job_ref, timeout=JOB_TIMEOUT)
 
         execute_results = qnx.jobs.results(execute_job_ref)
 

--- a/integration/test_rng.py
+++ b/integration/test_rng.py
@@ -12,6 +12,8 @@ from qnexus.models.references import (
     ExecutionResultRef,
 )
 
+from constants import JOB_TIMEOUT
+
 
 def get_rng_circuit(seed: int, n_rng: int, test_index: bool = False) -> Circuit:
     """Creates a single qubit pytket circuit to test RNGs.
@@ -121,7 +123,7 @@ def test_rng(
 
                 # Case 1: Executing a circuit with the same seed and no index
                 #         multiple times should give the same RNG numbers in all shots.
-                qnx.jobs.wait_for(execute_job_case1)
+                qnx.jobs.wait_for(execute_job_case1, timeout=JOB_TIMEOUT)
                 results_same = qnx.jobs.results(execute_job_case1)
                 rng1_A_result_ref = results_same[0]
                 rng1_B_result_ref = results_same[1]
@@ -150,7 +152,7 @@ def test_rng(
 
                 # Case 2: Executing the same circuit with the same seed and changing the
                 #         index should give different RNG numbers in all shots.
-                qnx.jobs.wait_for(execute_job_case2)
+                qnx.jobs.wait_for(execute_job_case2, timeout=JOB_TIMEOUT)
                 results_index = qnx.jobs.results(execute_job_case2)
                 rng2_result_ref = results_index[0]
                 assert isinstance(rng2_result_ref, ExecutionResultRef)
@@ -172,7 +174,7 @@ def test_rng(
 
                 # Case 3: Executing the circuit with a different seed should give
                 #         a different RNG number than the case 1 execution.
-                qnx.jobs.wait_for(execute_job_case3)
+                qnx.jobs.wait_for(execute_job_case3, timeout=JOB_TIMEOUT)
                 results_diff = qnx.jobs.results(execute_job_case3)
                 rng3_result_ref = results_diff[0]
                 assert isinstance(rng3_result_ref, ExecutionResultRef)

--- a/integration/test_wasm_modules.py
+++ b/integration/test_wasm_modules.py
@@ -10,6 +10,8 @@ import qnexus as qnx
 from qnexus.models.job_status import JobStatusEnum
 from qnexus.models.references import Ref, WasmModuleRef
 
+from constants import JOB_TIMEOUT
+
 
 def test_wasm_download(
     test_case_name: str,
@@ -92,5 +94,5 @@ def test_wasm_flow(
             project=proj_ref,
         )
 
-        qnx.jobs.wait_for(execute_job_ref)
+        qnx.jobs.wait_for(execute_job_ref, timeout=JOB_TIMEOUT)
         assert qnx.jobs.status(execute_job_ref).status == JobStatusEnum.COMPLETED

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict-markers -n 2 --reruns 3 --cov=qnexus --cov-report= --cov-append --doctest-modules
+addopts = --strict-markers -n 2 --reruns 3 --cov=qnexus --cov-report=term --doctest-modules
 norecursedirs = tests/data
 markers =
     create: marks tests as those that have side effects involving resource creation (deselect with '-m "not create"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict-markers -n 2 --reruns 3 --cov=qnexus --cov-report=term --doctest-modules
+addopts = --strict-markers -n 4 --reruns 3 --cov=qnexus --cov-report=term --doctest-modules
 norecursedirs = tests/data
 markers =
     create: marks tests as those that have side effects involving resource creation (deselect with '-m "not create"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict-markers -n 4 --reruns 3 --cov=qnexus --cov-report=term --doctest-modules
+addopts = --strict-markers -n 4 --reruns 3 --cov=qnexus --cov-report= --cov-append --doctest-modules
 norecursedirs = tests/data
 markers =
     create: marks tests as those that have side effects involving resource creation (deselect with '-m "not create"')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --strict-markers -n 4 --reruns 3 --cov=qnexus --cov-report= --cov-append --doctest-modules
+addopts = --strict-markers -n 2 --reruns 3 --cov=qnexus --cov-report= --cov-append --doctest-modules
 norecursedirs = tests/data
 markers =
     create: marks tests as those that have side effects involving resource creation (deselect with '-m "not create"')

--- a/qnexus/client/circuits.py
+++ b/qnexus/client/circuits.py
@@ -346,6 +346,7 @@ def cost(
     backend_config: BackendConfig,
     syntax_checker: str | None = None,
     project: ProjectRef | None = None,
+    timeout: float | None = None,
 ) -> float | None:
     """Estimate the cost (in HQC) of running Circuit programs for n_shots
     number of shots on a Quantinuum H2 system.
@@ -403,6 +404,6 @@ def cost(
         project=project,
         name="Circuit cost estimation job",
     )
-    status = qnx.jobs.wait_for(job_ref)
+    status = qnx.jobs.wait_for(job_ref, timeout=timeout)
 
     return cast(float, status.cost)

--- a/qnexus/client/hugr.py
+++ b/qnexus/client/hugr.py
@@ -301,6 +301,7 @@ def cost(
     n_shots: int | list[int],
     project: ProjectRef | None = None,
     system_name: Literal["Helios-1"] = "Helios-1",
+    timeout: float | None = None,
 ) -> float:
     """Estimate the cost (in HQC) of running Hugr programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -326,7 +327,7 @@ def cost(
         project=project,
         name="Hugr cost estimation job",
     )
-    status = qnx.jobs.wait_for(job_ref)
+    status = qnx.jobs.wait_for(job_ref, timeout=timeout)
 
     return cast(float, status.cost)
 
@@ -336,6 +337,7 @@ def cost_confidence(
     n_shots: int | list[int],
     project: ProjectRef | None = None,
     system_name: Literal["Helios-1"] = "Helios-1",
+    timeout: float | None = None,
 ) -> list[tuple[float, float]]:
     """Estimate the cost (in HQC) of running Hugr programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -345,6 +347,10 @@ def cost_confidence(
     NB: This will execute a costing job on a dedicated cost estimation device.
         Once run, the cost will be visible also in the Nexus web portal
         as part of the job.
+
+    Args:
+        timeout: Overall timeout in seconds to wait for the costing job to
+            complete. None for no timeout (default: None).
 
     Examples:
         >>> import qnexus as qnx
@@ -370,7 +376,7 @@ def cost_confidence(
         name="Circuit cost confidence estimation job",
     )
 
-    qnx.jobs.wait_for(job_ref)
+    qnx.jobs.wait_for(job_ref, timeout=timeout)
 
     return qnx.jobs.cost_confidence(job_ref)
 

--- a/qnexus/client/qir.py
+++ b/qnexus/client/qir.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from typing import Any, Literal, Union, cast
 from uuid import UUID
 
-from integration.constants import JOB_TIMEOUT
 import qnexus.exceptions as qnx_exc
 from qnexus.client import get_nexus_client
 from qnexus.client.nexus_iterator import NexusIterator
@@ -282,6 +281,7 @@ def cost(
     n_shots: int | list[int],
     project: ProjectRef | None = None,
     system_name: Literal["Helios-1"] = "Helios-1",
+    timeout: float | None = None,
 ) -> float:
     """Estimate the cost (in HQC) of running QIR programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -307,7 +307,7 @@ def cost(
         project=project,
         name="QIR cost estimation job",
     )
-    status = qnx.jobs.wait_for(job_ref)
+    status = qnx.jobs.wait_for(job_ref, timeout=timeout)
 
     return cast(float, status.cost)
 
@@ -317,6 +317,7 @@ def cost_confidence(
     n_shots: int | list[int],
     project: ProjectRef | None = None,
     system_name: Literal["Helios-1"] = "Helios-1",
+    timeout: float | None = None,
 ) -> list[tuple[float, float]]:
     """Estimate the cost (in HQC) of running QIR programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -326,6 +327,10 @@ def cost_confidence(
     NB: This will execute a costing job on a dedicated cost estimation device.
         Once run, the cost will be visible also in the Nexus web portal
         as part of the job.
+
+    Args:
+        timeout: Overall timeout in seconds to wait for the costing job to
+            complete. None for no timeout (default: None).
     """
     import qnexus as qnx
 
@@ -340,7 +345,7 @@ def cost_confidence(
         name="QIR cost estimation job",
     )
 
-    qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
+    qnx.jobs.wait_for(job_ref, timeout=timeout)
 
     return qnx.jobs.cost_confidence(job_ref)
 

--- a/qnexus/client/qir.py
+++ b/qnexus/client/qir.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, Literal, Union, cast
 from uuid import UUID
 
+from integration.constants import JOB_TIMEOUT
 import qnexus.exceptions as qnx_exc
 from qnexus.client import get_nexus_client
 from qnexus.client.nexus_iterator import NexusIterator
@@ -339,7 +340,7 @@ def cost_confidence(
         name="QIR cost estimation job",
     )
 
-    qnx.jobs.wait_for(job_ref)
+    qnx.jobs.wait_for(job_ref, timeout=JOB_TIMEOUT)
 
     return qnx.jobs.cost_confidence(job_ref)
 

--- a/qnexus/config.py
+++ b/qnexus/config.py
@@ -42,6 +42,8 @@ class Config(BaseSettings):
     # testing
     qa_user_email: str = ""
     qa_user_password: str = ""
+    qa_home_user_email: str = ""
+    qa_home_user_password: str = ""
 
     def __str__(self) -> str:
         """String representation of current config."""


### PR DESCRIPTION
AC:

Design cross island testing for qnexus.
Make changes to workflow to have separate job for test-cross-region-integration,
Follow same design as other tests:
- Update workflow to run cross island job separately (skip in normal integration test job)
- Separate conftest. 
- Same device fetching.
- Use same result parsing. 

Tests: 
- NG device HUGR
- NG device QIR
- OG device QIR
- OG device Pytket 
- Negative tests to throw 400 when running a cross island job on remote target region
- Update test_gpu_decoder_config_flow to throw error and skip for now.
- Add timeouts explicitly to `wait_for` function. 

Additional changes:
Updated one qir test that wastes too much time in retries when its too quick to reach queued state. 

