### PR TITLE
chore: investigate timeout method thread

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,6 +78,7 @@ jobs:
                         --html=integration-results.html \
                         --junit-xml=integration-results.xml \
                         --timeout=600 \
+                        --timeout-method=thread \
                         -ra --reruns=3 \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
@@ -152,6 +153,7 @@ jobs:
                         --junit-xml=cross-region-integration-results.xml \
                         --timeout=600 \
                         -ra --reruns=3 \
+                        --timeout-method=thread \
                         --run-id="${{ github.run_id }}(${{ github.run_attempt }})" \
                         --purge-projects \
                         -o addopts="--strict-markers -n 2" \


### PR DESCRIPTION
Use timeout method thread instead of signal:
what it does is it detects the hanging test and forces the worker to stop. Once the worker has died pytest-xdist will replace the worker and rerun the test.

```
integration/test_auth_flows.py::test_get_token_expiry 
[gw0] [ 91%] PASSED integration/test_qir.py::test_costing_qir_on_NG_devices 
[gw1] [ 92%] PASSED integration/test_auth_flows.py::test_get_token_expiry 
[gw2] node down: Not properly terminated
[gw2] [ 93%] RERUN integration/test_compiler_options.py::test_target_2qb_gate[ZZMax] 

replacing crashed worker gw2
integration/test_compiler_options.py::test_target_2qb_gate[ZZMax] 
```

Please refer to this run: https://github.com/Quantinuum/qnexus/actions/runs/31805613965/job/94783689125
