### PR TITLE
feat: automatically select a default cost estimation system based on region (temporary)

### DIFF
--- a/integration/test_qir.py
+++ b/integration/test_qir.py
@@ -275,6 +275,7 @@ def test_qir_cost_confidence(
             n_shots=[10],
             project=project_ref,
             timeout=JOB_TIMEOUT,
+            system_name="Helios-1",
         )
         assert isinstance(cost_confidence, list)
         assert len(cost_confidence) > 0

--- a/integration/test_qsys_jobs.py
+++ b/integration/test_qsys_jobs.py
@@ -142,6 +142,7 @@ def test_hugr_cost_confidence(
             n_shots=[10],
             project=project_ref,
             timeout=JOB_TIMEOUT,
+            system_name="Helios-1",
         )
         assert isinstance(cost_confidence, list)
         assert len(cost_confidence) > 0

--- a/qnexus/client/hugr.py
+++ b/qnexus/client/hugr.py
@@ -46,7 +46,7 @@ from qnexus.models.references import (
     ProjectRef,
     WasmModuleRef,
 )
-from qnexus.models.region import Region, get_costing_system_for_region
+from qnexus.models.region import Region, _get_costing_system_for_region
 from qnexus.models.scope import ScopeFilterEnum
 
 
@@ -323,7 +323,7 @@ def cost(
         category=DeprecationWarning,
     )
 
-    system_name = system_name or get_costing_system_for_region(target_region)
+    system_name = system_name or _get_costing_system_for_region(target_region)
 
     if isinstance(programs, HUGRRef):
         programs = [programs]
@@ -377,7 +377,7 @@ def cost_confidence(
     """
     import qnexus as qnx
 
-    system_name = system_name or get_costing_system_for_region(target_region)
+    system_name = system_name or _get_costing_system_for_region(target_region)
 
     if isinstance(programs, HUGRRef):
         programs = [programs]

--- a/qnexus/client/hugr.py
+++ b/qnexus/client/hugr.py
@@ -23,6 +23,7 @@ from qnexus.context import (
     merge_project_from_context,
     merge_properties_from_context,
     merge_scope_from_context,
+    merge_target_region_from_context,
 )
 from qnexus.models import HeliosConfig
 from qnexus.models.annotations import Annotations, CreateAnnotations, PropertiesDict
@@ -40,9 +41,12 @@ from qnexus.models.filters import (
 from qnexus.models.references import (
     DataframableList,
     ExecutionProgram,
+    GpuDecoderConfigRef,
     HUGRRef,
     ProjectRef,
+    WasmModuleRef,
 )
+from qnexus.models.region import Region, get_costing_system_for_region
 from qnexus.models.scope import ScopeFilterEnum
 
 
@@ -296,12 +300,14 @@ def update(
     )
 
 
+@merge_target_region_from_context
 def cost(
     programs: HUGRRef | list[HUGRRef],
     n_shots: int | list[int],
     project: ProjectRef | None = None,
-    system_name: Literal["Helios-1"] = "Helios-1",
+    system_name: Literal["Helios-1", "Helios-2"] | None = None,
     timeout: float | None = None,
+    target_region: Region | None = None,
 ) -> float:
     """Estimate the cost (in HQC) of running Hugr programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -317,6 +323,8 @@ def cost(
         category=DeprecationWarning,
     )
 
+    system_name = system_name or get_costing_system_for_region(target_region)
+
     if isinstance(programs, HUGRRef):
         programs = [programs]
 
@@ -326,18 +334,23 @@ def cost(
         backend_config=HeliosConfig(system_name=f"{system_name}SC"),
         project=project,
         name="Hugr cost estimation job",
+        target_region=target_region,
     )
     status = qnx.jobs.wait_for(job_ref, timeout=timeout)
 
     return cast(float, status.cost)
 
 
+@merge_target_region_from_context
 def cost_confidence(
     programs: HUGRRef | list[HUGRRef],
     n_shots: int | list[int],
     project: ProjectRef | None = None,
-    system_name: Literal["Helios-1"] = "Helios-1",
+    system_name: Literal["Helios-1", "Helios-2"] | None = None,
     timeout: float | None = None,
+    target_region: Region | None = None,
+    wasm_module: WasmModuleRef | None = None,
+    gpu_decoder_config: GpuDecoderConfigRef | None = None,
 ) -> list[tuple[float, float]]:
     """Estimate the cost (in HQC) of running Hugr programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -364,6 +377,8 @@ def cost_confidence(
     """
     import qnexus as qnx
 
+    system_name = system_name or get_costing_system_for_region(target_region)
+
     if isinstance(programs, HUGRRef):
         programs = [programs]
 
@@ -374,6 +389,9 @@ def cost_confidence(
         backend_config=HeliosConfig(system_name=f"{system_name}SC"),
         project=project,
         name="Circuit cost confidence estimation job",
+        target_region=target_region,
+        wasm_module=wasm_module,
+        gpu_decoder_config=gpu_decoder_config,
     )
 
     qnx.jobs.wait_for(job_ref, timeout=timeout)

--- a/qnexus/client/qir.py
+++ b/qnexus/client/qir.py
@@ -15,6 +15,7 @@ from qnexus.context import (
     merge_project_from_context,
     merge_properties_from_context,
     merge_scope_from_context,
+    merge_target_region_from_context,
 )
 from qnexus.models import HeliosConfig, QuantinuumConfig
 from qnexus.models.annotations import Annotations, CreateAnnotations, PropertiesDict
@@ -32,9 +33,12 @@ from qnexus.models.filters import (
 from qnexus.models.references import (
     DataframableList,
     ExecutionProgram,
+    GpuDecoderConfigRef,
     ProjectRef,
     QIRRef,
+    WasmModuleRef,
 )
+from qnexus.models.region import Region, get_costing_system_for_region
 from qnexus.models.scope import ScopeFilterEnum
 
 
@@ -280,8 +284,9 @@ def cost(
     programs: QIRRef | list[QIRRef],
     n_shots: int | list[int],
     project: ProjectRef | None = None,
-    system_name: str = "Helios-1",
+    system_name: str | None = None,
     timeout: float | None = None,
+    target_region: Region | None = None,
 ) -> float:
     """Estimate the cost (in HQC) of running QIR programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -293,9 +298,11 @@ def cost(
     import qnexus as qnx
 
     warnings.warn(
-        "qir.cost() is deprecated. Please update to use qir.cost_confidence() instead.",
+        "qir.cost() is deprecated for Helios systems or newer. Please update to use qir.cost_confidence() instead.",
         category=DeprecationWarning,
     )
+
+    system_name = system_name or get_costing_system_for_region(target_region)
 
     if isinstance(programs, QIRRef):
         programs = [programs]
@@ -312,12 +319,16 @@ def cost(
     return cast(float, status.cost)
 
 
+@merge_target_region_from_context
 def cost_confidence(
     programs: QIRRef | list[QIRRef],
     n_shots: int | list[int],
     project: ProjectRef | None = None,
-    system_name: str = "Helios-1",
+    system_name: str | None = None,
     timeout: float | None = None,
+    target_region: Region | None = None,
+    wasm_module: WasmModuleRef | None = None,
+    gpu_decoder_config: GpuDecoderConfigRef | None = None,
 ) -> list[tuple[float, float]]:
     """Estimate the cost (in HQC) of running QIR programs for n_shots
     number of shots on a Quantinuum Helios system.
@@ -334,6 +345,8 @@ def cost_confidence(
     """
     import qnexus as qnx
 
+    system_name = system_name or get_costing_system_for_region(target_region)
+
     if isinstance(programs, QIRRef):
         programs = [programs]
 
@@ -343,6 +356,9 @@ def cost_confidence(
         backend_config=_costing_backend_config(system_name),
         project=project,
         name="QIR cost estimation job",
+        target_region=target_region,
+        wasm_module=wasm_module,
+        gpu_decoder_config=gpu_decoder_config,
     )
 
     qnx.jobs.wait_for(job_ref, timeout=timeout)

--- a/qnexus/client/qir.py
+++ b/qnexus/client/qir.py
@@ -38,7 +38,7 @@ from qnexus.models.references import (
     QIRRef,
     WasmModuleRef,
 )
-from qnexus.models.region import Region, get_costing_system_for_region
+from qnexus.models.region import Region, _get_costing_system_for_region
 from qnexus.models.scope import ScopeFilterEnum
 
 
@@ -302,7 +302,7 @@ def cost(
         category=DeprecationWarning,
     )
 
-    system_name = system_name or get_costing_system_for_region(target_region)
+    system_name = system_name or _get_costing_system_for_region(target_region)
 
     if isinstance(programs, QIRRef):
         programs = [programs]
@@ -345,7 +345,7 @@ def cost_confidence(
     """
     import qnexus as qnx
 
-    system_name = system_name or get_costing_system_for_region(target_region)
+    system_name = system_name or _get_costing_system_for_region(target_region)
 
     if isinstance(programs, QIRRef):
         programs = [programs]

--- a/qnexus/models/region.py
+++ b/qnexus/models/region.py
@@ -37,7 +37,7 @@ def _get_home_region() -> Region:
             raise ValueError(f"Unknown home region: {CONFIG.domain}")
 
 
-def get_costing_system_for_region(
+def _get_costing_system_for_region(
     region: Region | None = None,
 ) -> str:
     """Get the default costing system name for a given region.

--- a/qnexus/models/region.py
+++ b/qnexus/models/region.py
@@ -1,7 +1,11 @@
 """Region model for QNexus API client."""
 
 import os
+import warnings
 from typing import Literal
+
+from qnexus.config import CONFIG
+from qnexus.models.utils import assert_never
 
 Region = Literal["us", "sg"]
 
@@ -19,3 +23,39 @@ def get_hostname(region: Region) -> str:
     if region == "sg":
         return "nexus.quantinuum.sg"
     raise ValueError(f"Invalid region: {region}")
+
+
+def _get_home_region() -> Region:
+    """Infer the home region for the current environment from the domain."""
+
+    match CONFIG.domain:
+        case "nexus.quantinuum.com":
+            return "us"
+        case "nexus.quantinuum.sg":
+            return "sg"
+        case _:
+            raise ValueError(f"Unknown home region: {CONFIG.domain}")
+
+
+def get_costing_system_for_region(
+    region: Region | None = None,
+) -> str:
+    """Get the default costing system name for a given region.
+    Internal only function to be used before setting an automatic system is deprecated.
+    """
+
+    warnings.warn(
+        "system_name is unset so defaulting based on region. system_name will be required in a future release.",
+        category=DeprecationWarning,
+    )
+
+    if region is None:
+        region = _get_home_region()
+
+    match region:
+        case "us":
+            return "Helios-1"
+        case "sg":
+            return "Helios-2"
+        case _:
+            assert_never(region)

--- a/tests/test_cost_system_default.py
+++ b/tests/test_cost_system_default.py
@@ -1,0 +1,163 @@
+"""Tests for default costing system name selection based on domain.
+
+Can be deleted once the automatic system selection is removed.
+"""
+
+import uuid
+import warnings
+from datetime import datetime
+from unittest import mock
+
+from qnexus.models.annotations import Annotations
+from qnexus.models.references import HUGRRef, ProjectRef, QIRRef
+
+
+def _make_project() -> ProjectRef:
+    """Create a mock ProjectRef for testing."""
+    return ProjectRef(
+        id=uuid.uuid4(),
+        annotations=Annotations(),
+        contents_modified=datetime.now(),
+    )
+
+
+def _make_hugr_ref(project: ProjectRef) -> HUGRRef:
+    """Create a mock HUGRRef for testing."""
+    return HUGRRef(
+        id=uuid.uuid4(),
+        annotations=Annotations(),
+        project=project,
+    )
+
+
+def _make_qir_ref(project: ProjectRef) -> QIRRef:
+    """Create a mock QIRRef for testing."""
+    return QIRRef(
+        id=uuid.uuid4(),
+        annotations=Annotations(),
+        project=project,
+    )
+
+
+class TestHugrCostConfidenceDefaultSystem:
+    """Tests for hugr.cost_confidence default system_name selection."""
+
+    def test_us_domain_defaults_to_helios_1(self) -> None:
+        """When domain is nexus.quantinuum.com, default system should be Helios-1."""
+        import qnexus.client.hugr as hugr_module
+
+        project = _make_project()
+        hugr_ref = _make_hugr_ref(project)
+
+        with (
+            mock.patch("qnexus.start_execute_job") as mock_start_execute_job,
+            mock.patch("qnexus.jobs.wait_for"),
+            mock.patch("qnexus.jobs.cost_confidence", return_value=[(1.0, 0.95)]),
+            mock.patch("qnexus.models.region.CONFIG") as mock_config,
+        ):
+            mock_config.domain = "nexus.quantinuum.com"
+            mock_start_execute_job.return_value = mock.MagicMock()
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                hugr_module.cost_confidence(
+                    programs=hugr_ref,
+                    n_shots=100,
+                    project=project,
+                )
+
+            # Check that start_execute_job was called with the correct backend_config
+            call_kwargs = mock_start_execute_job.call_args.kwargs
+            backend_config = call_kwargs["backend_config"]
+            assert backend_config.system_name == "Helios-1SC"
+
+    def test_sg_domain_defaults_to_helios_2(self) -> None:
+        """When domain is nexus.quantinuum.sg, default system should be Helios-2."""
+        import qnexus.client.hugr as hugr_module
+
+        project = _make_project()
+        hugr_ref = _make_hugr_ref(project)
+
+        with (
+            mock.patch("qnexus.start_execute_job") as mock_start_execute_job,
+            mock.patch("qnexus.jobs.wait_for"),
+            mock.patch("qnexus.jobs.cost_confidence", return_value=[(1.0, 0.95)]),
+            mock.patch("qnexus.models.region.CONFIG") as mock_config,
+        ):
+            mock_config.domain = "nexus.quantinuum.sg"
+            mock_start_execute_job.return_value = mock.MagicMock()
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                hugr_module.cost_confidence(
+                    programs=hugr_ref,
+                    n_shots=100,
+                    project=project,
+                )
+
+            # Check that start_execute_job was called with the correct backend_config
+            call_kwargs = mock_start_execute_job.call_args.kwargs
+            backend_config = call_kwargs["backend_config"]
+            assert backend_config.system_name == "Helios-2SC"
+
+
+class TestQirCostConfidenceDefaultSystem:
+    """Tests for qir.cost_confidence default system_name selection."""
+
+    def test_us_domain_defaults_to_helios_1(self) -> None:
+        """When domain is nexus.quantinuum.com, default system should be Helios-1."""
+        import qnexus.client.qir as qir_module
+
+        project = _make_project()
+        qir_ref = _make_qir_ref(project)
+
+        with (
+            mock.patch("qnexus.start_execute_job") as mock_start_execute_job,
+            mock.patch("qnexus.jobs.wait_for"),
+            mock.patch("qnexus.jobs.cost_confidence", return_value=[(1.0, 0.95)]),
+            mock.patch("qnexus.models.region.CONFIG") as mock_config,
+        ):
+            mock_config.domain = "nexus.quantinuum.com"
+            mock_start_execute_job.return_value = mock.MagicMock()
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                qir_module.cost_confidence(
+                    programs=qir_ref,
+                    n_shots=100,
+                    project=project,
+                )
+
+            # Check that start_execute_job was called with the correct backend_config
+            call_kwargs = mock_start_execute_job.call_args.kwargs
+            backend_config = call_kwargs["backend_config"]
+            assert backend_config.system_name == "Helios-1SC"
+
+    def test_sg_domain_defaults_to_helios_2(self) -> None:
+        """When domain is nexus.quantinuum.sg, default system should be Helios-2."""
+        import qnexus.client.qir as qir_module
+
+        project = _make_project()
+        qir_ref = _make_qir_ref(project)
+
+        with (
+            mock.patch("qnexus.start_execute_job") as mock_start_execute_job,
+            mock.patch("qnexus.jobs.wait_for"),
+            mock.patch("qnexus.jobs.cost_confidence", return_value=[(1.0, 0.95)]),
+            mock.patch("qnexus.models.region.CONFIG") as mock_config,
+        ):
+            mock_config.domain = "nexus.quantinuum.sg"
+            mock_start_execute_job.return_value = mock.MagicMock()
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                qir_module.cost_confidence(
+                    programs=qir_ref,
+                    n_shots=100,
+                    project=project,
+                )
+
+            # Check that start_execute_job was called with the correct backend_config
+            call_kwargs = mock_start_execute_job.call_args.kwargs
+            backend_config = call_kwargs["backend_config"]
+            assert backend_config.system_name == "Helios-2SC"

--- a/tests/test_cost_system_default.py
+++ b/tests/test_cost_system_default.py
@@ -8,6 +8,8 @@ import warnings
 from datetime import datetime
 from unittest import mock
 
+import pytest
+
 from qnexus.models.annotations import Annotations
 from qnexus.models.references import HUGRRef, ProjectRef, QIRRef
 
@@ -42,8 +44,21 @@ def _make_qir_ref(project: ProjectRef) -> QIRRef:
 class TestHugrCostConfidenceDefaultSystem:
     """Tests for hugr.cost_confidence default system_name selection."""
 
-    def test_us_domain_defaults_to_helios_1(self) -> None:
-        """When domain is nexus.quantinuum.com, default system should be Helios-1."""
+    @pytest.mark.parametrize(
+        "domain, target_region, expected_system",
+        [
+            # Domain-based defaults (no target_region)
+            ("nexus.quantinuum.com", None, "Helios-1SC"),
+            ("nexus.quantinuum.sg", None, "Helios-2SC"),
+            # target_region overrides domain
+            ("nexus.quantinuum.sg", "us", "Helios-1SC"),
+            ("nexus.quantinuum.com", "sg", "Helios-2SC"),
+        ],
+    )
+    def test_system_name_selection(
+        self, domain: str, target_region: str | None, expected_system: str
+    ) -> None:
+        """Verify correct Helios system is selected based on domain and target_region."""
         import qnexus.client.hugr as hugr_module
 
         project = _make_project()
@@ -55,57 +70,43 @@ class TestHugrCostConfidenceDefaultSystem:
             mock.patch("qnexus.jobs.cost_confidence", return_value=[(1.0, 0.95)]),
             mock.patch("qnexus.models.region.CONFIG") as mock_config,
         ):
-            mock_config.domain = "nexus.quantinuum.com"
+            mock_config.domain = domain
             mock_start_execute_job.return_value = mock.MagicMock()
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
-                hugr_module.cost_confidence(
-                    programs=hugr_ref,
-                    n_shots=100,
-                    project=project,
-                )
+                kwargs = {
+                    "programs": hugr_ref,
+                    "n_shots": 100,
+                    "project": project,
+                }
+                if target_region is not None:
+                    kwargs["target_region"] = target_region
+                hugr_module.cost_confidence(**kwargs)  # type: ignore[arg-type]
 
-            # Check that start_execute_job was called with the correct backend_config
             call_kwargs = mock_start_execute_job.call_args.kwargs
             backend_config = call_kwargs["backend_config"]
-            assert backend_config.system_name == "Helios-1SC"
-
-    def test_sg_domain_defaults_to_helios_2(self) -> None:
-        """When domain is nexus.quantinuum.sg, default system should be Helios-2."""
-        import qnexus.client.hugr as hugr_module
-
-        project = _make_project()
-        hugr_ref = _make_hugr_ref(project)
-
-        with (
-            mock.patch("qnexus.start_execute_job") as mock_start_execute_job,
-            mock.patch("qnexus.jobs.wait_for"),
-            mock.patch("qnexus.jobs.cost_confidence", return_value=[(1.0, 0.95)]),
-            mock.patch("qnexus.models.region.CONFIG") as mock_config,
-        ):
-            mock_config.domain = "nexus.quantinuum.sg"
-            mock_start_execute_job.return_value = mock.MagicMock()
-
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
-                hugr_module.cost_confidence(
-                    programs=hugr_ref,
-                    n_shots=100,
-                    project=project,
-                )
-
-            # Check that start_execute_job was called with the correct backend_config
-            call_kwargs = mock_start_execute_job.call_args.kwargs
-            backend_config = call_kwargs["backend_config"]
-            assert backend_config.system_name == "Helios-2SC"
+            assert backend_config.system_name == expected_system
 
 
 class TestQirCostConfidenceDefaultSystem:
     """Tests for qir.cost_confidence default system_name selection."""
 
-    def test_us_domain_defaults_to_helios_1(self) -> None:
-        """When domain is nexus.quantinuum.com, default system should be Helios-1."""
+    @pytest.mark.parametrize(
+        "domain, target_region, expected_system",
+        [
+            # Domain-based defaults (no target_region)
+            ("nexus.quantinuum.com", None, "Helios-1SC"),
+            ("nexus.quantinuum.sg", None, "Helios-2SC"),
+            # target_region overrides domain
+            ("nexus.quantinuum.sg", "us", "Helios-1SC"),
+            ("nexus.quantinuum.com", "sg", "Helios-2SC"),
+        ],
+    )
+    def test_system_name_selection(
+        self, domain: str, target_region: str | None, expected_system: str
+    ) -> None:
+        """Verify correct Helios system is selected based on domain and target_region."""
         import qnexus.client.qir as qir_module
 
         project = _make_project()
@@ -117,47 +118,20 @@ class TestQirCostConfidenceDefaultSystem:
             mock.patch("qnexus.jobs.cost_confidence", return_value=[(1.0, 0.95)]),
             mock.patch("qnexus.models.region.CONFIG") as mock_config,
         ):
-            mock_config.domain = "nexus.quantinuum.com"
+            mock_config.domain = domain
             mock_start_execute_job.return_value = mock.MagicMock()
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", DeprecationWarning)
-                qir_module.cost_confidence(
-                    programs=qir_ref,
-                    n_shots=100,
-                    project=project,
-                )
+                kwargs = {
+                    "programs": qir_ref,
+                    "n_shots": 100,
+                    "project": project,
+                }
+                if target_region is not None:
+                    kwargs["target_region"] = target_region
+                qir_module.cost_confidence(**kwargs)  # type: ignore[arg-type]
 
-            # Check that start_execute_job was called with the correct backend_config
             call_kwargs = mock_start_execute_job.call_args.kwargs
             backend_config = call_kwargs["backend_config"]
-            assert backend_config.system_name == "Helios-1SC"
-
-    def test_sg_domain_defaults_to_helios_2(self) -> None:
-        """When domain is nexus.quantinuum.sg, default system should be Helios-2."""
-        import qnexus.client.qir as qir_module
-
-        project = _make_project()
-        qir_ref = _make_qir_ref(project)
-
-        with (
-            mock.patch("qnexus.start_execute_job") as mock_start_execute_job,
-            mock.patch("qnexus.jobs.wait_for"),
-            mock.patch("qnexus.jobs.cost_confidence", return_value=[(1.0, 0.95)]),
-            mock.patch("qnexus.models.region.CONFIG") as mock_config,
-        ):
-            mock_config.domain = "nexus.quantinuum.sg"
-            mock_start_execute_job.return_value = mock.MagicMock()
-
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore", DeprecationWarning)
-                qir_module.cost_confidence(
-                    programs=qir_ref,
-                    n_shots=100,
-                    project=project,
-                )
-
-            # Check that start_execute_job was called with the correct backend_config
-            call_kwargs = mock_start_execute_job.call_args.kwargs
-            backend_config = call_kwargs["backend_config"]
-            assert backend_config.system_name == "Helios-2SC"
+            assert backend_config.system_name == expected_system


### PR DESCRIPTION
This PR seeks to avoid a breaking change in cost estimation by enabling the automatic selection of a syntax checker system in cost estimation based on the user's configured domain region (or target region).

Longer term we should remove the default and require explicit selection